### PR TITLE
add  policy to roles to prod

### DIFF
--- a/modules/fixtures/policies/bluepi_policy_basic.tmpl
+++ b/modules/fixtures/policies/bluepi_policy_basic.tmpl
@@ -203,7 +203,8 @@
         "wafv2:*",
         "waf-regional:*",
         "worklink:*",
-        "workspaces:*"
+        "workspaces:*",
+        "ssm-guiconnect:*"
       ],
       "Resource": "*",
       "Condition": {

--- a/modules/fixtures/policies/bluepi_policy_serverless.tmpl
+++ b/modules/fixtures/policies/bluepi_policy_serverless.tmpl
@@ -145,7 +145,8 @@
         "states:*",
         "sts:*",
         "tag:*",
-        "transfer:*"
+        "transfer:*",
+        "ssm-guiconnect:*"
       ],
       "Resource": "*",
       "Condition": {

--- a/modules/fixtures/policies/principal_policy.tmpl
+++ b/modules/fixtures/policies/principal_policy.tmpl
@@ -169,7 +169,8 @@
         "wafv2:*",
         "waf-regional:*",
         "worklink:*",
-        "workspaces:*"
+        "workspaces:*",
+        "ssm-guiconnect:*"
       ],
       "Resource": "*",
       "Condition": {


### PR DESCRIPTION
# Fixes : 
- add ssm-guiconnect policy to roles

Change will be reflected once an account is nuked , the master account will re create the roles and add the policy document from s3 bucket 
